### PR TITLE
limit cpu count to fix boot issue on machines with high core count

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -138,48 +138,22 @@ function create_dbconfig() {
      rm "${ORACLE_BASE}"/"${ORACLE_SID}".zip
   fi;
 
-  # If the host has a large number of CPUs (>= 32), SGA_TARGET needs to be increased (#64)
-  #
-  # Note: This does not apply to Oracle Database 11g XE which has a memory limit of 1 GB
-  # and does not require that much additional memory for a larger CPU count.
-  # 11g XE fails to start with the following error if more than 1 GB memory is configured:
-  #   ORA-47500: XE edition memory parameter invalid or not specified
-  if [[ "$ORACLE_VERSION" != "11.2."* ]] && (( "$(nproc --all)" >= 32 )); then
-    echo "CONTAINER: machine has high CPU count: $(nproc --all)"
-    #
-    # 16 = 640  MB
-    # 24 = 816  MB
-    # 32 = 992  MB
-    # 48 = 1344 MB
-    # 64 = 1696 MB
-    #
-    if   (( "$(nproc --all)" == 32 )); then
-      SGA_MEMORY="1100";
-      PGA_MEMORY="400";
-    elif (( "$(nproc --all)" <= 48 )); then
-      SGA_MEMORY="1500";
-      PGA_MEMORY="400";
-    else
-      SGA_MEMORY="1800";
-      PGA_MEMORY="200";
-    fi;
+  # If the host has a large number of CPUs (>= 32), Oracle requires a larger SGA_TARGET (#64).
+  # However, this continues to scale beyond 2GB for machines with e.g. 96+ cores,
+  # and oracle-xe only supports up to 2GB of memory.
+  # Therefore is is easier to just limit the maximum amount of CPUs oracle may use.
+  sqlplus -s / as sysdba <<EOF
+     -- Exit on any errors
+     WHENEVER SQLERROR EXIT SQL.SQLCODE
 
-    echo "CONTAINER: increasing SGA_TARGET to ${SGA_MEMORY}MB."
-    sqlplus -s / as sysdba <<EOF
-       -- Exit on any errors
-       WHENEVER SQLERROR EXIT SQL.SQLCODE
+     CREATE PFILE='/tmp/pfile.ora' FROM SPFILE;
+     HOST sed -i '/\*\.cpu_count.*/d' /tmp/pfile.ora
+     HOST echo '*.cpu_count=16' >> /tmp/pfile.ora
+     CREATE SPFILE FROM PFILE='/tmp/pfile.ora';
+     HOST rm /tmp/pfile.ora
 
-       CREATE PFILE='/tmp/pfile.ora' FROM SPFILE;
-       HOST sed -i 's/\*\.sga_target.*/\*\.sga_target=${SGA_MEMORY}m/g' /tmp/pfile.ora
-       HOST sed -i 's/\*\.pga_aggregate_target.*/\*\.pga_aggregate_target=${PGA_MEMORY}m/g' /tmp/pfile.ora
-       CREATE SPFILE FROM PFILE='/tmp/pfile.ora';
-       HOST rm /tmp/pfile.ora
-
-       exit;
+     exit;
 EOF
-
-    echo "CONTAINER: done increasing SGA_TARGET."
-  fi;
 
   mkdir -p "${ORACLE_BASE}/oradata/dbconfig/${ORACLE_SID}"
 


### PR DESCRIPTION
This fixes the issues I faced in https://github.com/gvenzl/oci-oracle-xe/issues/64

With this change I am successfully able to start the image on a 96-core host machine, which previously errored with `ORA-00821: Specified value of sga_target 1808M is too small, needs to be at least 2320M`.

According to the [documentation on CPU_COUNT](https://docs.oracle.com/en/database/oracle/oracle-database/21/refrn/CPU_COUNT.html#GUID-78CDCDE7-5A1D-4AC1-B5BD-B185CB296416), this is interpreted as a _maximum_ if used during initialization, so it shouldn't be a problem for machines with _fewer_ than 16 counts:

> However, if CPU_COUNT is set to a value greater than the current number of CPUs in the initialization parameter file, then CPU_COUNT is capped to the current number of CPUs.

I don't have a machine with fewer than 16 cores at hand, but I'll set this to 999 locally and see if that boots successfully too to verify it works. Building the image just takes a while each time 😅
