### PR TITLE
Add --nowait support from oracle/docker-images to facilitate use as a docker base image

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -435,6 +435,13 @@ else
   exit 1;
 fi;
 
+# Exiting the script without waiting on the tail logs
+if [ "${1:-}" = "--nowait" ]; then
+   # Creating state-file for identifyig container of the prebuiltdb extended image
+   touch "${ORACLE_BASE}/oradata/${ORACLE_SID}/.prebuiltdb"
+   exit;
+fi
+
 tail -f "${ORACLE_BASE}"/diag/rdbms/*/"${ORACLE_SID}"/trace/alert_"${ORACLE_SID}".log &
 childPID=$!
 wait ${childPID}


### PR DESCRIPTION
The container entrypoint script in oracle/docker-images has a --nowait argument that is needed for use as a base container.

https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/dockerfiles/21.3.0/runOracle.sh#L324

This PR adds support for --nowait, and has been tested with the 'set -Eeuo pipefail' setting.

The use case is a Dockerfile like this, that builds an Oracle container with the database already initialized.

FROM gvenzl/oracle-xe
COPY my_init_scripts/ /container-entrypoint-initdb.d/
WORKDIR ${ORACLE_BASE}
RUN ["container-entrypoint.sh", "--nowait"]

Thank you for making these containers.