### PR TITLE
Exposing port in dockerfile so it can be used in CI pipeline

### DIFF
--- a/Dockerfile.11202
+++ b/Dockerfile.11202
@@ -47,14 +47,16 @@ ENV ORACLE_BASE=/u01/app/oracle \
     ORACLE_SID=XE \
     PATH=${PATH}:/u01/app/oracle/product/11.2.0/xe/bin:/u01/app/oracle \
     NLS_LANG=.AL32UTF8
-    
+
 COPY oracle-xe-11.2.0-1.0.x86_64.rpm xe.11202.rsp install.11202.sh container-entrypoint.sh resetPassword createAppUser healthcheck.sh /install/
 
 RUN /install/install.11202.sh "${BUILD_MODE}"
-    
+
 USER oracle
 WORKDIR ${ORACLE_BASE}
 
 HEALTHCHECK CMD "${ORACLE_BASE}"/healthcheck.sh >/dev/null || exit 1
 
 ENTRYPOINT ["container-entrypoint.sh"]
+
+EXPOSE 1521/tcp

--- a/Dockerfile.1840
+++ b/Dockerfile.1840
@@ -33,10 +33,12 @@ ENV ORACLE_BASE=/opt/oracle \
 COPY oracle-database-xe-18c-1.0-1.x86_64.rpm install.1840.sh container-entrypoint.sh resetPassword createAppUser healthcheck.sh /install/
 
 RUN /install/install.1840.sh "${BUILD_MODE}"
-    
+
 USER oracle
 WORKDIR ${ORACLE_BASE}
 
 HEALTHCHECK CMD "${ORACLE_BASE}"/healthcheck.sh >/dev/null || exit 1
 
 ENTRYPOINT ["container-entrypoint.sh"]
+
+EXPOSE 1521/tcp

--- a/Dockerfile.2130
+++ b/Dockerfile.2130
@@ -33,10 +33,12 @@ ENV ORACLE_BASE=/opt/oracle \
 COPY oracle-database-xe-21c-1.0-1.ol8.x86_64.rpm install.2130.sh container-entrypoint.sh resetPassword createAppUser healthcheck.sh /install/
 
 RUN /install/install.2130.sh "${BUILD_MODE}"
-    
+
 USER oracle
 WORKDIR ${ORACLE_BASE}
 
 HEALTHCHECK CMD "${ORACLE_BASE}"/healthcheck.sh >/dev/null || exit 1
 
 ENTRYPOINT ["container-entrypoint.sh"]
+
+EXPOSE 1521/tcp


### PR DESCRIPTION
I'm currently facing an issue with gitlab to use this image as a service for my build because it doesn't expose any ports in its Dockerfile.