### PR TITLE
FIX: ORA-01017 in healthcheck.sh

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -29,7 +29,7 @@ ORACLE_VERSION=$(sqlplus -version | grep "Release" | awk '{ print $3 }')
 # 11g doesn't have PDBs yet, so just check v\$instance
 if [[ "${ORACLE_VERSION}" = "11.2"* ]]; then
 
-  db_status=$(sqlplus -s / << EOF
+  db_status=$(sqlplus -s / as sysdba << EOF
      set heading off;
      set pagesize 0;
      SELECT 'READY'
@@ -44,7 +44,7 @@ else
   #  Either the PDB passed on as \$ORACLE_DATABASE or the default "XEPDB1"
   DATABASE=${1:-${ORACLE_DATABASE:-XEPDB1}}
 
-  db_status=$(sqlplus -s / << EOF
+  db_status=$(sqlplus -s / as sysdba << EOF
      set heading off;
      set pagesize 0;
      SELECT 'READY'


### PR DESCRIPTION
In some cases, you get an error "ORA-01017: invalid username/password; logon denied" in the healthcheck, stopping the execution of the container when starting and the sqlplus connection fails in the healthcheck file. The problem occurred when migrating the dbf files from another oracle container.

![Captura de pantalla de 2024-05-24 09-32-31](https://github.com/gvenzl/oci-oracle-xe/assets/22661844/02d67518-0cbf-4fc8-9bc7-8605e82c8df8)

![Captura de pantalla de 2024-05-24 09-34-22](https://github.com/gvenzl/oci-oracle-xe/assets/22661844/29a96e8f-8daa-4a89-a35a-02dc6d62e0f5)

![Captura de pantalla de 2024-05-24 09-33-59](https://github.com/gvenzl/oci-oracle-xe/assets/22661844/4e2c19b7-db4c-4143-b5b0-a1715fbd4abf)
