### PR TITLE
Instead of sleep X, use docker logs -f for container to start.

### DIFF
--- a/examples/dkr-create-oracle-xe-server
+++ b/examples/dkr-create-oracle-xe-server
@@ -46,6 +46,9 @@ $CMG_COMMAND run --name $DKR_CNT_NAME \
   -d $DKR_IMAGE
 
 echo "Waiting for container '$DKR_CNT_NAME' to start ... " 
-sleep 10
+
+DKR_CNT_ID=$(docker inspect --format="{{.Id}}" "$DKR_CNT_NAME")
+timeout 60s grep -q 'DATABASE IS READY TO USE!' <(docker logs -f $DKR_CNT_ID) || exit 1
+
 
 echo "Docker Container '$DKR_CNT_NAME' has been started on port '$DKR_HOST_PORT'"


### PR DESCRIPTION
Change example 

use docker logs -f for container to start. Better than sleep for starting containers with long durations
